### PR TITLE
Fix hard-coded diffusion model type in trainer

### DIFF
--- a/train_ddpm/main.py
+++ b/train_ddpm/main.py
@@ -219,8 +219,12 @@ def main():
     logging.info("Exp comment = {}".format(args.comment))
 
     try:
-        runner = ConditionalDiffusion(args, config)
-        # runner = Diffusion(args, config)
+        if config.model.type == "simple":
+            runner = Diffusion(args, config)
+        elif config.model.type == "conditional":
+            runner = ConditionalDiffusion(args, config)
+        else:
+            raise AssertionError
         if args.sample:
             runner.sample()
         elif args.test:


### PR DESCRIPTION
I was getting an error when trying to train with the model type "simple", due to hard-coded ConditionalDiffusion. I added a check to see which model to use.